### PR TITLE
dps: Show not only names of containers, but also image and ports

### DIFF
--- a/dps
+++ b/dps
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker ps --format '{{.Names}}' "$@"
+docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}' "$@"


### PR DESCRIPTION
Hi!
I find it very useful to have also information about the image and the exposed ports of the running containers.